### PR TITLE
Fix right-edge clipping in 1bpp bitmap masking

### DIFF
--- a/Image2ZPL/Conversion/ZPLII.cs
+++ b/Image2ZPL/Conversion/ZPLII.cs
@@ -61,7 +61,10 @@ namespace Image2ZPL.Conversion
                 unsafe
                 {
                     byte* pixelData = (byte*)data.Scan0.ToPointer();
-                    byte mask = (byte)(0xff << (data.Stride * 8 - dim.Width));
+                    int validBitsInLastByte = dim.Width % 8;
+                    byte mask = validBitsInLastByte == 0
+                        ? (byte)0xFF
+                        : (byte)(0xFF << (8 - validBitsInLastByte));
                     imagebytes = new byte[dim.Height][];
 
                     for (int x = 0; x < dim.Height; x++)


### PR DESCRIPTION
This fixes an intermittent issue where the right-hand edge of 1bpp images could be clipped.

The problem was caused by the bit mask for the final byte of each row being calculated using the bitmap stride rather than the actual image width. Because stride includes padding bytes added for alignment, this could result in shifting by more than 8 bits. In those cases, the mask became 0x00, causing the entire last byte (and therefore valid pixels) to be cleared.

The fix recalculates the mask based solely on the number of valid pixels in the final byte (width % 8). This ensures that only unused bits are masked, and valid pixels at the right edge of the image are preserved regardless of stride padding.